### PR TITLE
Add travis CI part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: bash
+sudo: required
+services:
+  - docker
+
+before_install:
+  - docker pull golang:1.7.5
+  - docker pull node:6.11.0-slim
+  - docker pull f5devcentral/containthedocs
+
+script:
+  - set -e
+  - if [ "$DOCKER_NAMESPACE" == "" ]; then DOCKER_NAMESPACE="local"; fi
+  - BASE_PUSH_TARGET="$DOCKER_NAMESPACE/cf-bigip-ctlr"
+  - |
+    if [ "$DOCKER_P" == "" -o "$DOCKER_U" == "" -o $DOCKER_NAMESPACE == "" ]; then
+      echo "[INFO] Docker user, password, or namespace vars absent from travis-ci."
+      echo "[INFO] See DEVEL.md section 'Travis Builds' to configure travis with DockerHub."
+    else
+      docker login -u="$DOCKER_U" -p="$DOCKER_P"
+      DOCKER_READY="true"
+    fi
+  - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
+  - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
+  - export CLEAN_BUILD=true
+  - export BASE_OS=alpine
+  - ./build-tools/build-devel-image.sh
+  - ./build-tools/run-in-docker.sh make verify
+  - ./build-tools/build-debug-artifacts.sh
+  - ./build-tools/build-release-artifacts.sh
+  - ./build-tools/build-release-images.sh
+  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+  - |
+    if [ "$DOCKER_READY" ]; then
+      docker push "$IMG_TAG"
+      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+    fi
+

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -33,4 +33,19 @@ k8s.io/client-go/kubernetes/typed/apps/v1beta1, but since that package wasn't
 in vendor it satisfied that import with the version of the package that was in
 $GOAPTH.
 
+## Travis builds on GitHub
 
+To run system/integration tests against a development image your fork will need to be configured to work with travis.org and you will need a docker hub repository to accpet the images. 
+
+GitHub:
+- Navigate to `github.com/<user-name>/cf-bigip-cltr/settings/installations`
+- Search for "travis" and click on it to add. 
+
+Travis:
+- Navigate to `travis-ci.org/profile/<_github_user_name>`.
+- Click "Sync account".
+- Click on `cf-bigip-ctlr` fork, then on "settings".
+- Add `DOCKER_U`, `DOCKER_P` and `DOCKER_NAMESPACE` -- this is the user or organization name on Docker Hub, and may be different than `DOCKER_U` in organziations.
+
+In Docker Hub:  
+- Add a repo to that account named `cf-bigip-ctlr`.

--- a/build-tools/python-tests.sh
+++ b/build-tools/python-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# run python style and unit tests
+# simplified to run in build-devel-image
+
+set -ex
+
+CURDIR="$(dirname $BASH_SOURCE)"
+
+. $CURDIR/_build-lib.sh
+BUILDDIR=$(get_builddir)
+
+export BUILDDIR=$BUILDDIR
+
+(cd python && flake8 . --exclude src,lib,go,bin,docs,cmd)
+(cd python && pytest . -slvv --ignore=src/ -p no:cacheprovider)
+
+if [ "$TRAVIS_REPO_SLUG" != "" ]; then
+  if [ "$COVERALLS_TOKEN" ]; then
+    echo "Converting python coverage to goveralls format..."
+    (cd python && coveralls --output=$BUILDDIR/coverage.json)
+    python build-tools/python-coverage.py $BUILDDIR/coverage.json $BUILDDIR/python-coverage.txt
+  else
+    echo "[INFO] Not an 'F5Networks' commit, coverage optional."
+    echo "[INFO] See README.md section 'build' to configure travis with coveralls."
+  fi
+fi

--- a/build-tools/python-tests.sh
+++ b/build-tools/python-tests.sh
@@ -5,23 +5,5 @@
 
 set -ex
 
-CURDIR="$(dirname $BASH_SOURCE)"
-
-. $CURDIR/_build-lib.sh
-BUILDDIR=$(get_builddir)
-
-export BUILDDIR=$BUILDDIR
-
 (cd python && flake8 . --exclude src,lib,go,bin,docs,cmd)
 (cd python && pytest . -slvv --ignore=src/ -p no:cacheprovider)
-
-if [ "$TRAVIS_REPO_SLUG" != "" ]; then
-  if [ "$COVERALLS_TOKEN" ]; then
-    echo "Converting python coverage to goveralls format..."
-    (cd python && coveralls --output=$BUILDDIR/coverage.json)
-    python build-tools/python-coverage.py $BUILDDIR/coverage.json $BUILDDIR/python-coverage.txt
-  else
-    echo "[INFO] Not an 'F5Networks' commit, coverage optional."
-    echo "[INFO] See README.md section 'build' to configure travis with coveralls."
-  fi
-fi

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -14,8 +14,5 @@ go_install $(all_pkgs)
 
 ginkgo_test_with_coverage
 
-# reset GOPATH after using temp directories
-export GOPATH=/build
-
 # run python tests
 ./build-tools/python-tests.sh

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -6,7 +6,16 @@ set -e
 CURDIR="$(dirname $BASH_SOURCE)"
 
 . $CURDIR/_build-lib.sh
+BUILDDIR=$(get_builddir)
+
+export BUILDDIR=$BUILDDIR
 
 go_install $(all_pkgs)
 
 ginkgo_test_with_coverage
+
+# reset GOPATH after using temp directories
+export GOPATH=/build
+
+# run python tests
+./build-tools/python-tests.sh

--- a/python/tests/test_bigipconfigdriver.py
+++ b/python/tests/test_bigipconfigdriver.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 from copy import deepcopy
 import json
 import logging
@@ -28,7 +30,7 @@ import f5_cccl._f5
 
 import pytest
 
-import bigipconfigdriver
+from .. import bigipconfigdriver
 
 _args_app_name = ['bigipconfigdriver.py']
 

--- a/python/tests/test_k8scloudbigip.py
+++ b/python/tests/test_k8scloudbigip.py
@@ -17,12 +17,14 @@
 Units tests for testing BIG-IP resource management in Kubernetes and OpenShift.
 
 """
+from __future__ import absolute_import
+
 import unittest
 from mock import Mock, patch
 from f5_cccl.common import ipv4_to_mac
 from f5.bigip import BigIP
 from f5_cccl.testcommon import BigIPTest, MockIapp
-ctlr = __import__('bigipconfigdriver')
+from .. import bigipconfigdriver as ctlr
 
 
 class VxLANTunnel():


### PR DESCRIPTION
Problem:
Repo needs CI that tests code, and pushes images to dockerhub.

Solution:
Added .travis.yml that builds and pushes an image to dockerhub that can be used for system tests and nightly regressions.

Note:
CI set up is being broken into two stages to simplify moving ongoing development. Created issue #12 for CI part 2.