### PR TITLE
Fixed * resolution in policy rules.

### DIFF
--- a/f5router/bigipResources/bigipResources.go
+++ b/f5router/bigipResources/bigipResources.go
@@ -97,6 +97,7 @@ type (
 	// Condition for a rule
 	Condition struct {
 		Equals      bool     `json:"equals,omitempty"`
+		StartsWith  bool     `json:"startsWith,omitempty"`
 		EndsWith    bool     `json:"endsWith,omitempty"`
 		Host        bool     `json:"host,omitempty"`
 		HTTPHost    bool     `json:"httpHost,omitempty"`

--- a/f5router/f5router_test.go
+++ b/f5router/f5router_test.go
@@ -163,6 +163,10 @@ var _ = Describe("F5Router", func() {
 			baz2Segment3Endpoint,
 			wildCfEndpoint,
 			wildFooEndpoint,
+			wildEndEndpoint,
+			wildMidEndpoint,
+			wildBeginEndpoint,
+			wild2Endpoint,
 			quxEndpoint *route.Endpoint
 		)
 
@@ -178,6 +182,10 @@ var _ = Describe("F5Router", func() {
 				routePair{"baz.cf.com/segment1/segment2/segment3", baz2Segment3Endpoint},
 				routePair{"*.cf.com", wildCfEndpoint},
 				routePair{"*.foo.cf.com", wildFooEndpoint},
+				routePair{"ser*.cf.com", wildEndEndpoint},
+				routePair{"ser*es.cf.com", wildMidEndpoint},
+				routePair{"*vices.cf.com", wildBeginEndpoint},
+				routePair{"*vic*.cf.com", wild2Endpoint},
 			}
 			for _, pair := range rp {
 				up, _ = NewUpdate(logger, routeUpdate.Add, pair.url, pair.ep)
@@ -206,6 +214,10 @@ var _ = Describe("F5Router", func() {
 			baz2Segment3Endpoint = makeEndpoint("127.0.4.2")
 			wildCfEndpoint = makeEndpoint("127.0.5.1")
 			wildFooEndpoint = makeEndpoint("127.0.6.1")
+			wildEndEndpoint = makeEndpoint("127.0.6.2")
+			wildMidEndpoint = makeEndpoint("127.0.6.3")
+			wildBeginEndpoint = makeEndpoint("127.0.6.4")
+			wild2Endpoint = makeEndpoint("127.0.7.1")
 			quxEndpoint = makeEndpoint("127.0.7.1")
 
 		})
@@ -271,6 +283,18 @@ var _ = Describe("F5Router", func() {
 			router.UpdateRoute(up)
 
 			up, err = NewUpdate(logger, routeUpdate.Remove, "*.foo.cf.com", wildFooEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			router.UpdateRoute(up)
+
+			up, err = NewUpdate(logger, routeUpdate.Remove, "ser*.cf.com", wildEndEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			router.UpdateRoute(up)
+
+			up, err = NewUpdate(logger, routeUpdate.Remove, "ser*es.cf.com", wildMidEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			router.UpdateRoute(up)
+
+			up, err = NewUpdate(logger, routeUpdate.Remove, "*vices.cf.com", wildBeginEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			router.UpdateRoute(up)
 

--- a/testdata/resources/config0.json
+++ b/testdata/resources/config0.json
@@ -14,8 +14,8 @@
       "virtualServers": [{
         "name": "routing-vip-http",
         "ipProtocol": "tcp",
-        "destination": "/cf/127.0.0.1:80",
         "enabled": true,
+        "destination": "/cf/127.0.0.1:80",
         "policies": [{
           "name": "cf-routing-policy",
           "partition": "cf"
@@ -26,15 +26,29 @@
         }]
       }],
       "pools": [{
-        "name": "cf-foo-e500900501f76ce8",
+        "name": "cf-bar-d21aa8a505891ac9",
         "loadBalancingMode": "round-robin",
         "members": [{
-          "address": "127.0.0.1",
+          "address": "127.0.1.1",
+          "port": 80,
+          "session": "user-enabled"
+        }, {
+          "address": "127.0.1.2",
           "port": 80,
           "session": "user-enabled"
         }],
         "monitors": ["/Common/tcp_half_open"],
-        "description": "route: foo.cf.com - App GUID: 1"
+        "description": "route: bar.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-baz-9a96ddcfe07bb46e",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.2.1",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: baz.cf.com - App GUID: 1"
       }, {
         "name": "cf-foo.cf.com",
         "loadBalancingMode": "round-robin",
@@ -46,15 +60,35 @@
         "monitors": ["/Common/tcp_half_open"],
         "description": "route: *.foo.cf.com - App GUID: 1"
       }, {
-        "name": "cf-baz-9a96ddcfe07bb46e",
+        "name": "cf-ser_.cf.com",
         "loadBalancingMode": "round-robin",
         "members": [{
-          "address": "127.0.2.1",
+          "address": "127.0.6.2",
           "port": 80,
           "session": "user-enabled"
         }],
         "monitors": ["/Common/tcp_half_open"],
-        "description": "route: baz.cf.com - App GUID: 1"
+        "description": "route: ser*.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-ser_es.cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.6.3",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: ser*es.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-foo-e500900501f76ce8",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.0.1",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: foo.cf.com - App GUID: 1"
       }, {
         "name": "cf-baz-69cf12df3b85f455",
         "loadBalancingMode": "round-robin",
@@ -94,19 +128,15 @@
         "monitors": ["/Common/tcp_half_open"],
         "description": "route: *.cf.com - App GUID: 1"
       }, {
-        "name": "cf-bar-d21aa8a505891ac9",
+        "name": "cf-_vices.cf.com",
         "loadBalancingMode": "round-robin",
         "members": [{
-          "address": "127.0.1.1",
-          "port": 80,
-          "session": "user-enabled"
-        }, {
-          "address": "127.0.1.2",
+          "address": "127.0.6.4",
           "port": 80,
           "session": "user-enabled"
         }],
         "monitors": ["/Common/tcp_half_open"],
-        "description": "route: bar.cf.com - App GUID: 1"
+        "description": "route: *vices.cf.com - App GUID: 1"
       }],
       "l7Policies": [{
         "controls": ["forwarding"],
@@ -244,6 +274,79 @@
           "actions": [{
             "forward": true,
             "name": "0",
+            "pool": "/cf/cf-ser_es.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "startsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["ser"]
+          }, {
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "1",
+            "index": 1,
+            "request": true,
+            "values": ["es.cf.com"]
+          }],
+          "name": "cf-ser_es.cf.com",
+          "ordinal": 5,
+          "description": "route: ser*es.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
+            "pool": "/cf/cf-ser_.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "startsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["ser"]
+          }, {
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "1",
+            "index": 1,
+            "request": true,
+            "values": [".cf.com"]
+          }],
+          "name": "cf-ser_.cf.com",
+          "ordinal": 6,
+          "description": "route: ser*.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
+            "pool": "/cf/cf-_vices.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["vices.cf.com"]
+          }],
+          "name": "cf-_vices.cf.com",
+          "ordinal": 7,
+          "description": "route: *vices.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
             "pool": "/cf/cf-foo.cf.com",
             "request": true
           }],
@@ -257,7 +360,7 @@
             "values": [".foo.cf.com"]
           }],
           "name": "cf-foo.cf.com",
-          "ordinal": 5,
+          "ordinal": 8,
           "description": "route: *.foo.cf.com - App GUID: 1"
         }, {
           "actions": [{
@@ -276,7 +379,7 @@
             "values": [".cf.com"]
           }],
           "name": "cf-cf.com",
-          "ordinal": 6,
+          "ordinal": 9,
           "description": "route: *.cf.com - App GUID: 1"
         }],
         "strategy": "/Common/first-match"

--- a/testdata/resources/config1.json
+++ b/testdata/resources/config1.json
@@ -14,8 +14,8 @@
       "virtualServers": [{
         "name": "routing-vip-http",
         "ipProtocol": "tcp",
-        "destination": "/cf/127.0.0.1:80",
         "enabled": true,
+        "destination": "/cf/127.0.0.1:80",
         "policies": [{
           "name": "cf-routing-policy",
           "partition": "cf"
@@ -64,16 +64,6 @@
         "monitors": ["/Common/tcp_half_open"],
         "description": "route: baz.cf.com/segment1/segment2/segment3 - App GUID: 1"
       }, {
-        "name": "cf-bar-d21aa8a505891ac9",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.1.2",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/tcp_half_open"],
-        "description": "route: bar.cf.com - App GUID: 1"
-      }, {
         "name": "cf-cf.com",
         "loadBalancingMode": "round-robin",
         "members": [{
@@ -83,6 +73,16 @@
         }],
         "monitors": ["/Common/tcp_half_open"],
         "description": "route: *.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-bar-d21aa8a505891ac9",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.1.2",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: bar.cf.com - App GUID: 1"
       }],
       "l7Policies": [{
         "controls": ["forwarding"],

--- a/testdata/resources/config2.json
+++ b/testdata/resources/config2.json
@@ -14,8 +14,8 @@
       "virtualServers": [{
         "name": "routing-vip-http",
         "ipProtocol": "tcp",
-        "destination": "/cf/127.0.0.1:80",
         "enabled": true,
+        "destination": "/cf/127.0.0.1:80",
         "policies": [{
           "name": "cf-routing-policy",
           "partition": "cf"
@@ -26,26 +26,6 @@
         }]
       }],
       "pools": [{
-        "name": "cf-qux-ac504dcd7f58634d",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.7.1",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/tcp_half_open"],
-        "description": "route: qux.cf.com - App GUID: 1"
-      }, {
-        "name": "cf-bar-d21aa8a505891ac9",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.1.2",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/tcp_half_open"],
-        "description": "route: bar.cf.com - App GUID: 1"
-      }, {
         "name": "cf-baz-9a96ddcfe07bb46e",
         "loadBalancingMode": "round-robin",
         "members": [{
@@ -69,6 +49,26 @@
         }],
         "monitors": ["/Common/tcp_half_open"],
         "description": "route: baz.cf.com/segment1 - App GUID: 1"
+      }, {
+        "name": "cf-qux-ac504dcd7f58634d",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.7.1",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: qux.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-bar-d21aa8a505891ac9",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.1.2",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/tcp_half_open"],
+        "description": "route: bar.cf.com - App GUID: 1"
       }, {
         "name": "cf-baz-beac6f8bec5a4446",
         "loadBalancingMode": "round-robin",

--- a/testdata/resources/config3.json
+++ b/testdata/resources/config3.json
@@ -14,8 +14,8 @@
       "virtualServers": [{
         "name": "routing-vip-http",
         "ipProtocol": "tcp",
-        "destination": "/cf/127.0.0.1:80",
         "enabled": true,
+        "destination": "/cf/127.0.0.1:80",
         "policies": [{
           "name": "fakepolicy",
           "partition": "Common"
@@ -36,8 +36,8 @@
       }, {
         "name": "routing-vip-https",
         "ipProtocol": "tcp",
-        "destination": "/cf/127.0.0.1:443",
         "enabled": true,
+        "destination": "/cf/127.0.0.1:443",
         "policies": [{
           "name": "fakepolicy",
           "partition": "Common"
@@ -60,6 +60,26 @@
         }]
       }],
       "pools": [{
+        "name": "cf-ser_.cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.6.2",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: ser*.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-_vices.cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.6.4",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: *vices.cf.com - App GUID: 1"
+      }, {
         "name": "cf-foo-e500900501f76ce8",
         "loadBalancingMode": "round-robin",
         "members": [{
@@ -69,6 +89,50 @@
         }],
         "monitors": ["/Common/potato"],
         "description": "route: foo.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-baz-beac6f8bec5a4446",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.4.1",
+          "port": 80,
+          "session": "user-enabled"
+        }, {
+          "address": "127.0.4.2",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: baz.cf.com/segment1/segment2/segment3 - App GUID: 1"
+      }, {
+        "name": "cf-cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.5.1",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: *.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-foo.cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.6.1",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: *.foo.cf.com - App GUID: 1"
+      }, {
+        "name": "cf-ser_es.cf.com",
+        "loadBalancingMode": "round-robin",
+        "members": [{
+          "address": "127.0.6.3",
+          "port": 80,
+          "session": "user-enabled"
+        }],
+        "monitors": ["/Common/potato"],
+        "description": "route: ser*es.cf.com - App GUID: 1"
       }, {
         "name": "cf-bar-d21aa8a505891ac9",
         "loadBalancingMode": "round-robin",
@@ -107,40 +171,6 @@
         }],
         "monitors": ["/Common/potato"],
         "description": "route: baz.cf.com/segment1 - App GUID: 1"
-      }, {
-        "name": "cf-baz-beac6f8bec5a4446",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.4.1",
-          "port": 80,
-          "session": "user-enabled"
-        }, {
-          "address": "127.0.4.2",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/potato"],
-        "description": "route: baz.cf.com/segment1/segment2/segment3 - App GUID: 1"
-      }, {
-        "name": "cf-cf.com",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.5.1",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/potato"],
-        "description": "route: *.cf.com - App GUID: 1"
-      }, {
-        "name": "cf-foo.cf.com",
-        "loadBalancingMode": "round-robin",
-        "members": [{
-          "address": "127.0.6.1",
-          "port": 80,
-          "session": "user-enabled"
-        }],
-        "monitors": ["/Common/potato"],
-        "description": "route: *.foo.cf.com - App GUID: 1"
       }],
       "l7Policies": [{
         "controls": ["forwarding"],
@@ -278,6 +308,79 @@
           "actions": [{
             "forward": true,
             "name": "0",
+            "pool": "/cf/cf-ser_es.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "startsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["ser"]
+          }, {
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "1",
+            "index": 1,
+            "request": true,
+            "values": ["es.cf.com"]
+          }],
+          "name": "cf-ser_es.cf.com",
+          "ordinal": 5,
+          "description": "route: ser*es.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
+            "pool": "/cf/cf-ser_.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "startsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["ser"]
+          }, {
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "1",
+            "index": 1,
+            "request": true,
+            "values": [".cf.com"]
+          }],
+          "name": "cf-ser_.cf.com",
+          "ordinal": 6,
+          "description": "route: ser*.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
+            "pool": "/cf/cf-_vices.cf.com",
+            "request": true
+          }],
+          "conditions": [{
+            "endsWith": true,
+            "host": true,
+            "httpHost": true,
+            "name": "0",
+            "index": 0,
+            "request": true,
+            "values": ["vices.cf.com"]
+          }],
+          "name": "cf-_vices.cf.com",
+          "ordinal": 7,
+          "description": "route: *vices.cf.com - App GUID: 1"
+        }, {
+          "actions": [{
+            "forward": true,
+            "name": "0",
             "pool": "/cf/cf-foo.cf.com",
             "request": true
           }],
@@ -291,7 +394,7 @@
             "values": [".foo.cf.com"]
           }],
           "name": "cf-foo.cf.com",
-          "ordinal": 5,
+          "ordinal": 8,
           "description": "route: *.foo.cf.com - App GUID: 1"
         }, {
           "actions": [{
@@ -310,7 +413,7 @@
             "values": [".cf.com"]
           }],
           "name": "cf-cf.com",
-          "ordinal": 6,
+          "ordinal": 9,
           "description": "route: *.cf.com - App GUID: 1"
         }],
         "strategy": "/Common/first-match"


### PR DESCRIPTION
Problem:
 Wildcards routes were not resolved correctly for trailing or midstring
 wildcards which would cause the BIG-IP to fail since it does not allow
 for wildcard characters in policy rules.

Solution:
 Add resolution for trailing and midstring wildcards for policy rules.

Fixes: #8