### PR TITLE
Fix coverage badge reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/F5Networks/cf-bigip-ctlr.svg?branch=master)](https://travis-ci.org/F5Networks/cf-bigip-ctlr) [![Coverage Status](https://coveralls.io/repos/github/F5Networks/cf-bigip-ctlr/badge.svg?branch=master)](https://coveralls.io/github/F5Networks/cf-bigip-ctlr?branch=master)
+[![Build Status](https://travis-ci.org/F5Networks/cf-bigip-ctlr.svg?branch=master)](https://travis-ci.org/F5Networks/cf-bigip-ctlr) [![Coverage Status](https://coveralls.io/repos/github/F5Networks/cf-bigip-ctlr/badge.svg?branch=HEAD)](https://coveralls.io/github/F5Networks/cf-bigip-ctlr?branch=HEAD)
 
 F5 BIG-IP Controller for Cloud Foundry
 ======================================


### PR DESCRIPTION
Problem:
Coveralls badge pointed at "master" is showing coverage is "unavilaable".

Solution:
Use `?branch=HEAD` to indicate which number to post.