### PR TITLE
Docker latest, Dockerfile.builder whitespace cleanup, pin image for systests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,12 @@ script:
   - ./build-tools/build-debug-artifacts.sh
   - ./build-tools/build-release-artifacts.sh
   - ./build-tools/build-release-images.sh
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
   - |
     if [ "$DOCKER_READY" ]; then
-      docker push "$IMG_TAG"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker push "$BASE_PUSH_TARGET"
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
     fi
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
+  - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
   - ./build-tools/build-devel-image.sh
@@ -33,8 +34,11 @@ script:
     if [ "$DOCKER_READY" ]; then
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
-      docker push "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$IMG_TAG"
+      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker push "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$BASE_PUSH_TARGET:latest"      
     fi
 
 deploy:

--- a/build-tools/Dockerfile.builder
+++ b/build-tools/Dockerfile.builder
@@ -55,12 +55,12 @@ RUN apk add --no-cache \
 	pip install -r /tmp/cf-build-requirements.txt && \
 	pip install -r /tmp/cf-runtime-requirements.txt && \
 	pip install -r /tmp/requirements.docs.txt && \
-  pip install virtualenv && \
+        pip install virtualenv && \
 	go get github.com/wadey/gocovmerge && \
-  go get github.com/nats-io/gnatsd && \
-  go get github.com/onsi/ginkgo/ginkgo && \
-  go get github.com/onsi/gomega && \
-  go get github.com/mattn/goveralls && \
+        go get github.com/nats-io/gnatsd && \
+        go get github.com/onsi/ginkgo/ginkgo && \
+        go get github.com/onsi/gomega && \
+        go get github.com/mattn/goveralls && \
 	chmod 755 /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/build-tools/build-release-images.sh
+++ b/build-tools/build-release-images.sh
@@ -25,6 +25,7 @@ ls -la $WKDIR
 
 docker build --force-rm ${NO_CACHE_ARGS} \
   -t $IMG_TAG \
+  --label BUILD_STAMP=$BUILD_STAMP \
   -f $WKDIR/Dockerfile.runtime \
   $WKDIR
 


### PR DESCRIPTION
Problem:
- Dockerhub images did not have "latest" tag
- images need to be able to be specifically referenced in automated regression tests

Solution:
- Updated tagging to included latest.
- Added timestamp to build tag and included that information as a docker label to make it available to docker inspect in regression set up.
- Standardized whitespace in `Dockerfile.builder`

Fixes #22
