### PR TITLE
Set Source Address Translation on virtuals

### DIFF
--- a/f5router/bigipResources/bigipResources.go
+++ b/f5router/bigipResources/bigipResources.go
@@ -52,13 +52,14 @@ type (
 
 	// Virtual server frontend
 	Virtual struct {
-		VirtualServerName string     `json:"name"`
-		PoolName          string     `json:"pool,omitempty"`
-		Mode              string     `json:"ipProtocol,omitempty"`
-		Enabled           bool       `json:"enabled,omitempty"`
-		Destination       string     `json:"destination,omitempty"`
-		Policies          []*NameRef `json:"policies,omitempty"`
-		Profiles          []*NameRef `json:"profiles,omitempty"`
+		VirtualServerName     string                `json:"name"`
+		PoolName              string                `json:"pool,omitempty"`
+		Mode                  string                `json:"ipProtocol,omitempty"`
+		Enabled               bool                  `json:"enabled,omitempty"`
+		Destination           string                `json:"destination,omitempty"`
+		Policies              []*NameRef            `json:"policies,omitempty"`
+		Profiles              []*NameRef            `json:"profiles,omitempty"`
+		SourceAddrTranslation SourceAddrTranslation `json:"sourceAddressTranslation,omitempty"`
 	}
 
 	// Pool Member
@@ -128,6 +129,11 @@ type (
 		Requires    []string `json:"requires"`
 		Rules       []*Rule  `json:"rules"`
 		Strategy    string   `json:"strategy"`
+	}
+
+	// SourceAddrTranslation is the Virtual Server Source Address Translation
+	SourceAddrTranslation struct {
+		Type string `json:"type"`
 	}
 
 	Policies []*Policy

--- a/f5router/f5router.go
+++ b/f5router/f5router.go
@@ -193,6 +193,7 @@ func (r *F5Router) validateConfig() error {
 func (r *F5Router) createHTTPVirtuals() {
 	plcs := r.generatePolicyList()
 	prfls := r.generateNameList(r.c.BigIP.Profiles)
+	srcAddrTrans := bigipResources.SourceAddrTranslation{Type: "automap"}
 	va := &bigipResources.VirtualAddress{
 		BindAddr: r.c.BigIP.ExternalAddr,
 		Port:     80,
@@ -206,6 +207,7 @@ func (r *F5Router) createHTTPVirtuals() {
 			"tcp",
 			plcs,
 			prfls,
+			srcAddrTrans,
 		)
 
 	if 0 != len(r.c.BigIP.SSLProfiles) {
@@ -224,6 +226,7 @@ func (r *F5Router) createHTTPVirtuals() {
 				"tcp",
 				plcs,
 				prfls,
+				srcAddrTrans,
 			)
 	}
 }
@@ -440,6 +443,7 @@ func makeVirtual(
 	mode string,
 	policies []*bigipResources.NameRef,
 	profiles []*bigipResources.NameRef,
+	srcAddrTrans bigipResources.SourceAddrTranslation,
 ) *bigipResources.Virtual {
 	// Validate the IP address, and create the destination
 	addr := net.ParseIP(virtualAddress.BindAddr)
@@ -457,13 +461,14 @@ func makeVirtual(
 			virtualAddress.Port)
 
 		vs := &bigipResources.Virtual{
-			Enabled:           true,
-			VirtualServerName: name,
-			PoolName:          poolName,
-			Destination:       destination,
-			Mode:              mode,
-			Policies:          policies,
-			Profiles:          profiles,
+			Enabled:               true,
+			VirtualServerName:     name,
+			PoolName:              poolName,
+			Destination:           destination,
+			Mode:                  mode,
+			Policies:              policies,
+			Profiles:              profiles,
+			SourceAddrTranslation: srcAddrTrans,
 		}
 		return vs
 	} else {

--- a/f5router/tcpUpdate.go
+++ b/f5router/tcpUpdate.go
@@ -77,6 +77,7 @@ func (tu updateTCP) CreateResources(c *config.Config) bigipResources.Resources {
 		"tcp",
 		[]*bigipResources.NameRef{},
 		[]*bigipResources.NameRef{},
+		bigipResources.SourceAddrTranslation{Type: "automap"},
 	)
 
 	if nil != vs {

--- a/testdata/resources/config0.json
+++ b/testdata/resources/config0.json
@@ -23,7 +23,10 @@
         "profiles": [{
           "name": "http",
           "partition": "Common"
-        }]
+        }],
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-bar-d21aa8a505891ac9",

--- a/testdata/resources/config1.json
+++ b/testdata/resources/config1.json
@@ -23,7 +23,10 @@
         "profiles": [{
           "name": "http",
           "partition": "Common"
-        }]
+        }],
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-baz-9a96ddcfe07bb46e",

--- a/testdata/resources/config2.json
+++ b/testdata/resources/config2.json
@@ -23,7 +23,10 @@
         "profiles": [{
           "name": "http",
           "partition": "Common"
-        }]
+        }],
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-baz-9a96ddcfe07bb46e",

--- a/testdata/resources/config3.json
+++ b/testdata/resources/config3.json
@@ -32,7 +32,10 @@
         }, {
           "name": "fakeprofile",
           "partition": "Common"
-        }]
+        }],
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "routing-vip-https",
         "ipProtocol": "tcp",
@@ -57,7 +60,10 @@
         }, {
           "name": "clientssl",
           "partition": "Common"
-        }]
+        }],
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-ser_.cf.com",

--- a/testdata/resources/config4.json
+++ b/testdata/resources/config4.json
@@ -16,31 +16,46 @@
         "pool": "cf-tcp-route-default-tcp-6010",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6010"
+        "destination": "/cf/127.0.0.1:6010",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6020",
         "pool": "cf-tcp-route-default-tcp-6020",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6020"
+        "destination": "/cf/127.0.0.1:6020",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6030",
         "pool": "cf-tcp-route-default-tcp-6030",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6030"
+        "destination": "/cf/127.0.0.1:6030",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6040",
         "pool": "cf-tcp-route-default-tcp-6040",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6040"
+        "destination": "/cf/127.0.0.1:6040",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6050",
         "pool": "cf-tcp-route-default-tcp-6050",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6050"
+        "destination": "/cf/127.0.0.1:6050",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-tcp-route-default-tcp-6010",

--- a/testdata/resources/config5.json
+++ b/testdata/resources/config5.json
@@ -16,31 +16,46 @@
         "pool": "cf-tcp-route-default-tcp-6060",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6060"
+        "destination": "/cf/127.0.0.1:6060",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6010",
         "pool": "cf-tcp-route-default-tcp-6010",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6010"
+        "destination": "/cf/127.0.0.1:6010",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6020",
         "pool": "cf-tcp-route-default-tcp-6020",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6020"
+        "destination": "/cf/127.0.0.1:6020",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6030",
         "pool": "cf-tcp-route-default-tcp-6030",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6030"
+        "destination": "/cf/127.0.0.1:6030",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }, {
         "name": "cf-tcp-route-default-tcp-6040",
         "pool": "cf-tcp-route-default-tcp-6040",
         "ipProtocol": "tcp",
         "enabled": true,
-        "destination": "/cf/127.0.0.1:6040"
+        "destination": "/cf/127.0.0.1:6040",
+        "sourceAddressTranslation": {
+          "type": "automap"
+        }
       }],
       "pools": [{
         "name": "cf-tcp-route-default-tcp-6010",


### PR DESCRIPTION
Problem:
This bit is not being set which causes traffic to not flow as intended

Solution:
Update controller to set Source Address Translation to 'automap' on all
created virtuals
Update test configs to verify this is now set as expected

Fixes #25 