### PR TITLE
Deploy docs on stable branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
+  - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
   - ./build-tools/build-devel-image.sh
   - ./build-tools/run-in-docker.sh ./build-tools/python-tests.sh
   - ./build-tools/run-in-docker.sh make verify
@@ -42,10 +43,11 @@ deploy:
   - provider: script
     skip_cleanup: true
     on:
-      branch: 1.0-stable
+      all_branches: true
       repo: F5Networks/cf-bigip-ctlr
+      condition: $TRAVIS_BRANCH == *"-stable"
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/cf-bigip-ctlr v1.0
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/cf-bigip-ctlr v$CTLR_VERSION
 
 notifications:
   slack:


### PR DESCRIPTION
Problem:
The current logic in the travis file has specific knowledge about
version numbers for stable branches when deploying product docs to
clouddocs. This should be done in a version agnostic manner.

Solution:
Added logic to the docs deploy step so that it is applicable across all
stable branches.

affects-branches: master