### PR TITLE
Document partition management and configuration enforcement

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -67,6 +67,12 @@ To do so, create the desired objects on the BIG-IP manually *before* adding them
 - SSL profiles
 - health monitors
 
+.. danger::
+ 
+   The |cfctlr| monitors the BIG-IP partition it manages for configuration changes. If it discovers changes, the Controller reapplies its own configuration to the BIG-IP system.
+   
+   F5 does not recommend making configuration changes to objects in any partition managed by the |cfctlr| via any other means (for example, the configuration utility, TMOS, or by syncing configuration with another device or service group). Doing so may result in disruption of service or unexpected behavior.
+
 .. _cfctlr-configuration:
 
 Configuration Parameters
@@ -83,6 +89,7 @@ Define the parameters in the ``env`` section of your `application manifest </con
    - ``ssl_profiles`` tells the |cfctlr| that it should create an HTTPS virtual server that uses the specified `BIG-IP SSL profiles`_.
 
 \
+
 
 +------------------------------------------+---------+----------+----------------+---------------------------------------------------------------------------------+----------------+
 | Parameter                                | Type    | Required | Default        | Description                                                                     | Allowed Values |


### PR DESCRIPTION
Problem: The following is not clearly stated in the documentation. Administrator changes in the Controller managed partition will result in BIG-IP configuration changes back to the state the Controller expects.

Solution: Explicit highlight this in the documentation.

Fixes #31