### PR TITLE
Added non-0 route domain support

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -26,3 +26,6 @@ Limitations
 * If using HTTPS, the SSL profile(s) defined in the application manifest only attach to the HTTPS virtual server.
 * The BIG-IP Controller only controls one partition on the BIG-IP device.
 * Version |release| does not support TCP routing.
+* The default route domain for a partition managed by an F5 controller cannot be changed once a controller has been deployed.
+  To specify a new default route domain, a new partition should be used.
+

--- a/f5router/f5router.go
+++ b/f5router/f5router.go
@@ -446,18 +446,23 @@ func makeVirtual(
 	srcAddrTrans bigipResources.SourceAddrTranslation,
 ) *bigipResources.Virtual {
 	// Validate the IP address, and create the destination
-	addr := net.ParseIP(virtualAddress.BindAddr)
+	ip, rd := split_ip_with_route_domain(virtualAddress.BindAddr)
+	if len(rd) > 0 {
+		rd = "%" + rd
+	}
+	addr := net.ParseIP(ip)
 	if nil != addr {
 		var format string
 		if nil != addr.To4() {
-			format = "/%s/%s:%d"
+			format = "/%s/%s%s:%d"
 		} else {
-			format = "/%s/%s.%d"
+			format = "/%s/%s%s.%d"
 		}
 		destination := fmt.Sprintf(
 			format,
 			partition,
-			virtualAddress.BindAddr,
+			ip,
+			rd,
 			virtualAddress.Port)
 
 		vs := &bigipResources.Virtual{

--- a/f5router/routeDomain.go
+++ b/f5router/routeDomain.go
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2016,2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR conditionS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package f5router
+
+import (
+	"regexp"
+)
+
+func split_ip_with_route_domain(address string) (ip string, rd string) {
+	// Split the address into the ip and routeDomain (optional) parts
+	//     address is of the form: <ipv4_or_ipv6>[%<routeDomainID>]
+	idRdRegex := regexp.MustCompile(`^([^%]*)%(\d+)$`)
+
+	match := idRdRegex.FindStringSubmatch(address)
+	if match != nil {
+		ip = match[1]
+		rd = match[2]
+	} else {
+		ip = address
+		rd = ""
+	}
+	return
+}

--- a/f5router/routeDomain_test.go
+++ b/f5router/routeDomain_test.go
@@ -1,0 +1,61 @@
+/*-
+ * Copyright (c) 2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package f5router
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Route Domain", func() {
+	It("split_ip_with_route_domain", func() {
+		type testDataType struct {
+			address    string
+			expectedIP string
+			expectedRD string
+		}
+		testData := []testDataType{
+			{
+				address:    "",
+				expectedIP: "",
+				expectedRD: "",
+			}, {
+				address:    "1.2.3.4",
+				expectedIP: "1.2.3.4",
+				expectedRD: "",
+			}, {
+				address:    "fe80::",
+				expectedIP: "fe80::",
+				expectedRD: "",
+			}, {
+				address:    "1.2.3.4%56",
+				expectedIP: "1.2.3.4",
+				expectedRD: "56",
+			}, {
+				address:    "fe80::%0",
+				expectedIP: "fe80::",
+				expectedRD: "0",
+			},
+		}
+
+		for _, td := range testData {
+			ip, rd := split_ip_with_route_domain(td.address)
+			Expect(ip).To(Equal(td.expectedIP))
+			Expect(rd).To(Equal(td.expectedRD))
+		}
+	})
+})

--- a/python/cf-build-requirements.txt
+++ b/python/cf-build-requirements.txt
@@ -1,6 +1,6 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9d0546b332503fae3bee256e4d61400c3813eb86#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 pytest==3.0.2
 mock
-flake8
+flake8==3.4.1
 pytest-cov==2.5.1
 coveralls==1.1

--- a/python/cf-runtime-requirements.txt
+++ b/python/cf-runtime-requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9d0546b332503fae3bee256e4d61400c3813eb86#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 pyinotify==0.9.6


### PR DESCRIPTION
Problem:  Need to make sure controllers handle Big-IP addresses that
          have optional route domain IDs specified.
Solution: Updating BindAddr processing to look for optional route
          domains when processing the BindAddr field.