### PR TITLE
Use attributions-generator from DockerHub

### DIFF
--- a/build-tools/attributions-generator.sh
+++ b/build-tools/attributions-generator.sh
@@ -7,7 +7,7 @@
 set -e
 set -x
 
-ATTR_GEN_IMG=docker-registry.pdbld.f5net.com/velcro/attributions-generator:master
+ATTR_GEN_IMG=f5devcentral/attributions-generator:latest
 docker pull ${ATTR_GEN_IMG}
 
 RUN_ARGS=( \


### PR DESCRIPTION
Problem:
travis build fails when running attributions-generator step

Solution:
Point travis to the proper docker registry (DockerHub) to get
the attributions-generator image from.