### PR TITLE
remove redundant builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
   - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
   - ./build-tools/build-devel-image.sh
   - ./build-tools/run-in-docker.sh ./build-tools/python-tests.sh
-  - ./build-tools/run-in-docker.sh make verify
   - ./build-tools/build-debug-artifacts.sh
   - ./build-tools/build-release-artifacts.sh
   - ./build-tools/build-release-images.sh

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ pre-build:
 
 prod-build: pre-build
 	@echo "Building with minimal instrumentation..."
+	$(CURDIR)/build-tools/build-devel-image.sh
 	$(CURDIR)/build-tools/build-release-artifacts.sh
 	$(CURDIR)/build-tools/build-release-images.sh
 

--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -77,7 +77,7 @@ ginkgo_test_with_coverage () {
   (
     export GOBIN="$BUILDDIR/bin"
     echodo cd "$WKDIR/src/$PKGIMPORT"
-    echodo ginkgo -r -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
+    echodo ginkgo -r -compilers 1 -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
     echo "Gathering unit test code coverage for 'release' build..."
     gather_coverage $WKDIR
     rm -rf $WKDIR
@@ -93,7 +93,7 @@ ginkgo_test_with_profile () {
   (
     export GOBIN="$BUILDDIR/bin"
     echodo cd "$WKDIR/src/$PKGIMPORT"
-    echodo ginkgo -r -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 \
+    echodo ginkgo -r -compilers 1 -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 \
             ${BUILD_VARIANT_FLAGS} -- \
             -test.cpuprofile profile.cpu \
             -test.blockprofile profile.block \

--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -77,7 +77,7 @@ ginkgo_test_with_coverage () {
   (
     export GOBIN="$BUILDDIR/bin"
     echodo cd "$WKDIR/src/$PKGIMPORT"
-    echodo ginkgo -r -compilers 1 -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
+    echodo ginkgo -r -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
     echo "Gathering unit test code coverage for 'release' build..."
     gather_coverage $WKDIR
     rm -rf $WKDIR
@@ -93,7 +93,7 @@ ginkgo_test_with_profile () {
   (
     export GOBIN="$BUILDDIR/bin"
     echodo cd "$WKDIR/src/$PKGIMPORT"
-    echodo ginkgo -r -compilers 1 -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 \
+    echodo ginkgo -r -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 \
             ${BUILD_VARIANT_FLAGS} -- \
             -test.cpuprofile profile.cpu \
             -test.blockprofile profile.block \

--- a/build-tools/build-debug-artifacts.sh
+++ b/build-tools/build-debug-artifacts.sh
@@ -9,15 +9,7 @@ CURDIR="$(dirname $BASH_SOURCE)"
 
 . $CURDIR/_build-lib.sh
 
-# Build the builder image.
-$CURDIR/build-devel-image.sh
-
 # Build artifacts using the build image
 export build_img=$BUILD_DBG_IMG_TAG
+$CURDIR/run-in-docker.sh make verify
 $CURDIR/run-in-docker.sh ./build-tools/dbg-build.sh
-
-if $CLEAN_BUILD; then
-  docker rmi $build_img
-fi
-
-# Now ready to run ./build-devel-image.sh

--- a/build-tools/build-release-artifacts.sh
+++ b/build-tools/build-release-artifacts.sh
@@ -9,9 +9,6 @@ CURDIR="$(dirname $BASH_SOURCE)"
 
 . $CURDIR/_build-lib.sh
 
-# Build the builder image.
-$CURDIR/build-devel-image.sh
-
 # Build artifacts using the build image
 $CURDIR/run-in-docker.sh ./build-tools/rel-build.sh
 


### PR DESCRIPTION
Problem:
Build process was building images multiple times.

Solution:
Applied modificiations from https://github.com/F5Networks/k8s-bigip-ctlr/pull/355 as the same build scripts/patterns are used for both repos.

Fixes #28