### PR TITLE
Added session persistence changes.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,8 @@ type Config struct {
 	PidFile     string `yaml:"pid_file"`
 	LoadBalance string `yaml:"balancing_algorithm"`
 
+	SessionPersistence bool `yaml:"session_persistence"`
+
 	DisableKeepAlives   bool `yaml:"disable_keep_alives"`
 	MaxIdleConns        int  `yaml:"max_idle_conns"`
 	MaxIdleConnsPerHost int  `yaml:"max_idle_conns_per_host"`
@@ -240,6 +242,8 @@ var defaultConfig = Config{
 	RouteMode: HTTP.String(),
 
 	LoadBalance: LOAD_BALANCE_RR,
+
+	SessionPersistence: true,
 
 	DisableKeepAlives:   true,
 	MaxIdleConns:        100,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,21 @@ balancing_algorithm: foo-bar
 			})
 		})
 
+		Context("session persistence config", func() {
+			It("sets default session persistence", func() {
+				Expect(config.SessionPersistence).To(Equal(true))
+			})
+
+			It("can override the default session persistence", func() {
+				cfg := DefaultConfig()
+				var b = []byte(`session_persistence: false`)
+
+				cfg.Initialize(b)
+				cfg.Process()
+				Expect(cfg.SessionPersistence).To(Equal(false))
+			})
+		})
+
 		It("sets router group config", func() {
 			var b = []byte(`
 router_group: test

--- a/f5router/bigipResources/JsessionidIRule.go
+++ b/f5router/bigipResources/JsessionidIRule.go
@@ -1,0 +1,55 @@
+/*-
+ * Copyright (c) 2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigipResources
+
+const (
+	// JSESSIONIDiRuleName on BIG-IP
+	JsessionidIRuleName = "jsessionid-persistence"
+
+	// JSESSIONID iRule on the BIG-IP
+	JsessionidIRule = `
+when HTTP_RESPONSE {
+  set jsessionid [lsearch -inline -regexp [HTTP::cookie names] (?i)^jsessionid$]
+  if { $jsessionid ne "" } {
+    set maxAge [HTTP::cookie maxage $jsessionid]
+    if { $maxAge < 0 } {
+      persist add uie [HTTP::cookie $jsessionid] 3600
+    } elseif { $maxAge == 0 } {
+      if { [persist lookup uie [HTTP::cookie $jsessionid]] } {
+        persist delete uie [HTTP::cookie $jsessionid]
+      }
+    } else {
+      persist add uie [HTTP::cookie $jsessionid] $maxAge
+    }
+  }
+}
+when HTTP_REQUEST {
+  set jsessionid [lsearch -inline -regexp [HTTP::cookie names] (?i)^jsessionid$]
+  if { $jsessionid ne "" } {
+    set forwardNode [persist lookup uie [HTTP::cookie $jsessionid] node]
+    set forwardPort [persist lookup uie [HTTP::cookie $jsessionid] port]
+    set forwardIP $forwardNode:$forwardPort
+    if { $forwardNode ne "" && $forwardPort ne "" } {
+      node $forwardIP
+    } else {
+      log local0. "Could not find endpoint for persistence record: [HTTP::cookie $jsessionid]. \
+      Check to see if this record still exists (check Statistics -> Module Statistics -> Local \
+      Traffic -> Persistence Records) or the status of the records endpoint."
+    }
+  }
+}`
+)

--- a/f5router/bigipResources/bigipResources.go
+++ b/f5router/bigipResources/bigipResources.go
@@ -48,6 +48,7 @@ type (
 		Pools    []*Pool    `json:"pools,omitempty"`
 		Monitors []*Monitor `json:"monitors,omitempty"`
 		Policies []*Policy  `json:"l7Policies,omitempty"`
+		IRules   []*IRule   `json:"iRules,omitempty"`
 	}
 
 	// Virtual server frontend
@@ -59,6 +60,7 @@ type (
 		Destination           string                `json:"destination,omitempty"`
 		Policies              []*NameRef            `json:"policies,omitempty"`
 		Profiles              []*NameRef            `json:"profiles,omitempty"`
+		IRules                []string              `json:"rules,omitempty"`
 		SourceAddrTranslation SourceAddrTranslation `json:"sourceAddressTranslation,omitempty"`
 	}
 
@@ -129,6 +131,12 @@ type (
 		Requires    []string `json:"requires"`
 		Rules       []*Rule  `json:"rules"`
 		Strategy    string   `json:"strategy"`
+	}
+
+	// IRule definition
+	IRule struct {
+		Name string `json:"name"`
+		Code string `json:"apiAnonymous"`
 	}
 
 	// SourceAddrTranslation is the Virtual Server Source Address Translation

--- a/f5router/f5router_test.go
+++ b/f5router/f5router_test.go
@@ -317,7 +317,7 @@ var _ = Describe("F5Router", func() {
 			Eventually(done).Should(BeClosed(), "timed out waiting for Run to complete")
 		})
 
-		It("should handle policies, profiles and health monitors", func() {
+		It("should handle policies, profiles, session persistence, and health monitors", func() {
 			done := make(chan struct{})
 			os := make(chan os.Signal)
 			ready := make(chan struct{})
@@ -327,6 +327,7 @@ var _ = Describe("F5Router", func() {
 			c.BigIP.Profiles = []string{"Common/http", "/Common/fakeprofile"}
 			c.BigIP.Policies = []string{"Common/fakepolicy", "/cf/anotherpolicy"}
 			c.BigIP.LoadBalancingMode = "least-connections-member"
+			c.SessionPersistence = false
 
 			router, err = NewF5Router(logger, c, mw)
 

--- a/f5router/tcpUpdate.go
+++ b/f5router/tcpUpdate.go
@@ -69,6 +69,7 @@ func (tu updateTCP) CreateResources(c *config.Config) bigipResources.Resources {
 	}
 
 	// pass in empty objs for profile and policy as we don't attach any currently
+	var iRules []string
 	vs := makeVirtual(
 		tu.name,
 		tu.name,
@@ -77,6 +78,7 @@ func (tu updateTCP) CreateResources(c *config.Config) bigipResources.Resources {
 		"tcp",
 		[]*bigipResources.NameRef{},
 		[]*bigipResources.NameRef{},
+		iRules,
 		bigipResources.SourceAddrTranslation{Type: "automap"},
 	)
 

--- a/testdata/resources/config0.json
+++ b/testdata/resources/config0.json
@@ -24,6 +24,7 @@
           "name": "http",
           "partition": "Common"
         }],
+        "rules": ["jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config1.json
+++ b/testdata/resources/config1.json
@@ -24,6 +24,7 @@
           "name": "http",
           "partition": "Common"
         }],
+        "rules": ["jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config2.json
+++ b/testdata/resources/config2.json
@@ -24,6 +24,7 @@
           "name": "http",
           "partition": "Common"
         }],
+        "rules": ["jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }


### PR DESCRIPTION
Problem:
 Current controller could not configure JSESSIONID session persistence
 on the BIG-IP.

Solution:
 Add optional opt out JSESSIONID session persistence BIG-IP
 configuration the same way that it is done in cloud foundry go router.