### PR TITLE
Updated session persistence iRule.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,7 @@ v1.0.0
 
 Added Functionality
 ```````````````````
+* Support for JSESSIONID cookie session persistence.
 * Support for TCP and HTTP routing.
 * Attach custom policy, profile, or health monitor to L7 objects created on the BIG-IP device.
 * Manages the following Local Traffic Manager (LTM) resources for the BIG-IP partition:
@@ -36,4 +37,3 @@ Limitations
 * SSL profile(s) defined in the application manifest do not attach to the HTTP virtual server.
 * Modification of a Controller-owned policy resulting in a state change may cause traffic flow interruptions. If the modification changes the state to ‘published’, the Controller will delete the policy and recreate it with a ‘legacy’ status.
 * You cannot change the default route domain for a partition managed by an F5 controller after the controller has deployed. To specify a new default route domain, use a different partition.
-

--- a/f5router/bigipResources/JsessionidIRule.go
+++ b/f5router/bigipResources/JsessionidIRule.go
@@ -24,29 +24,31 @@ const (
 	JsessionidIRule = `
 when HTTP_RESPONSE {
   set jsessionid [lsearch -inline -regexp [HTTP::cookie names] (?i)^jsessionid$]
+  set cookieVal [HTTP::cookie value $jsessionid]
   if { $jsessionid ne "" } {
     set maxAge [HTTP::cookie maxage $jsessionid]
     if { $maxAge < 0 } {
-      persist add uie [HTTP::cookie $jsessionid] 3600
+      persist add uie $cookieVal 3600
     } elseif { $maxAge == 0 } {
-      if { [persist lookup uie [HTTP::cookie $jsessionid]] } {
-        persist delete uie [HTTP::cookie $jsessionid]
+      if { [persist lookup uie $cookieVal] } {
+        persist delete uie $cookieVal
       }
     } else {
-      persist add uie [HTTP::cookie $jsessionid] $maxAge
+      persist add uie $cookieVal $maxAge
     }
   }
 }
 when HTTP_REQUEST {
   set jsessionid [lsearch -inline -regexp [HTTP::cookie names] (?i)^jsessionid$]
+  set cookieVal [HTTP::cookie value $jsessionid]
   if { $jsessionid ne "" } {
-    set forwardNode [persist lookup uie [HTTP::cookie $jsessionid] node]
-    set forwardPort [persist lookup uie [HTTP::cookie $jsessionid] port]
+    set forwardNode [persist lookup uie $cookieVal node]
+    set forwardPort [persist lookup uie $cookieVal port]
     set forwardIP $forwardNode:$forwardPort
     if { $forwardNode ne "" && $forwardPort ne "" } {
       node $forwardIP
     } else {
-      log local0. "Could not find endpoint for persistence record: [HTTP::cookie $jsessionid]. \
+      log local0. "Could not find endpoint for persistence record: $cookieVal. \
       Check to see if this record still exists (check Statistics -> Module Statistics -> Local \
       Traffic -> Persistence Records) or the status of the records endpoint."
     }


### PR DESCRIPTION
Problem:
 Even though you can get a cookies value by [HTTP:cookie <name>] this
 causes TCL warnings to be printed in the logs.

Solution:
 Change [HTTP:cookie <name>] to [HTTP:cookie value <name>] to squash
 warnings and also set a local variable with this lookup value so we do
 not have to keep looking up this cookie's value everytime we need it.