### PR TITLE
Update config output to match cccl expectations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,7 @@ type Tracing struct {
 }
 
 var defaultLoggingConfig = LoggingConfig{
-	Level:         "debug",
+	Level:         "info",
 	MetronAddress: "localhost:3457",
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -138,7 +138,7 @@ suspend_pruning_if_nats_unavailable: true
 
 		It("sets default logging configs", func() {
 			Expect(config.Logging.Syslog).To(Equal(""))
-			Expect(config.Logging.Level).To(Equal("debug"))
+			Expect(config.Logging.Level).To(Equal("info"))
 			Expect(config.Logging.LoggregatorEnabled).To(Equal(false))
 		})
 

--- a/f5router/bigipResources/bigipResources.go
+++ b/f5router/bigipResources/bigipResources.go
@@ -44,6 +44,13 @@ type (
 		Partition string `json:"partition"`
 	}
 
+	// ProfileRef references to pre-existing profiles
+	ProfileRef struct {
+		Name      string `json:"name"`
+		Partition string `json:"partition"`
+		Context   string `json:"context"` // 'clientside', 'serverside', or 'all'
+	}
+
 	// Configs for each BIG-IP partition
 	PartitionMap map[string]*Resources
 
@@ -66,7 +73,7 @@ type (
 		Destination           string                `json:"destination,omitempty"`
 		SourceAddress         string                `json:"source,omitempty"`
 		Policies              []*NameRef            `json:"policies,omitempty"`
-		Profiles              []*NameRef            `json:"profiles,omitempty"`
+		Profiles              []*ProfileRef         `json:"profiles,omitempty"`
 		IRules                []string              `json:"rules,omitempty"`
 		SourceAddrTranslation SourceAddrTranslation `json:"sourceAddressTranslation,omitempty"`
 	}

--- a/f5router/tcpUpdate.go
+++ b/f5router/tcpUpdate.go
@@ -73,12 +73,25 @@ func (tu updateTCP) CreateResources(c *config.Config) (bigipResources.Resources,
 	pool := makePool(c, tu.name, poolDescrip, tu.member)
 	rs.Pools = append(rs.Pools, pool)
 
+	profile := []*bigipResources.ProfileRef{
+		&bigipResources.ProfileRef{
+			Name:      "tcp",
+			Partition: "Common",
+			Context:   "all",
+		}}
+
+	poolPath, err := joinBigipPath(c.BigIP.Partitions[0], tu.name)
+	if nil != err {
+		return bigipResources.Resources{}, err
+	}
+
 	vs := &bigipResources.Virtual{
 		VirtualServerName:     tu.name,
-		PoolName:              tu.name,
+		PoolName:              poolPath,
 		Mode:                  "tcp",
 		Enabled:               true,
 		Destination:           dest,
+		Profiles:              profile,
 		SourceAddrTranslation: bigipResources.SourceAddrTranslation{Type: "automap"},
 	}
 

--- a/python/cf-build-requirements.txt
+++ b/python/cf-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9bd8f2668d48e28c7fdc848b5ab0ab06a37e68e1#egg=f5-cccl
+-e git+https://github.com/dramich/f5-cccl.git@5aaa584f9fc77742eb9d976954e6dad805e6f4ff#egg=f5-cccl
 pytest==3.0.2
 mock
 flake8==3.4.1

--- a/python/cf-runtime-requirements.txt
+++ b/python/cf-runtime-requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9bd8f2668d48e28c7fdc848b5ab0ab06a37e68e1#egg=f5-cccl
+-e git+https://github.com/dramich/f5-cccl.git@5aaa584f9fc77742eb9d976954e6dad805e6f4ff#egg=f5-cccl
 pyinotify==0.9.6

--- a/python/tests/test_cloudbigip.py
+++ b/python/tests/test_cloudbigip.py
@@ -63,6 +63,8 @@ class CloudTest(unittest.TestCase):
             Mock()
         self.cccl._service_manager._service_deployer.deploy_ltm = \
             Mock(return_value=0)
+        self.cccl._bigip_proxy.get_default_route_domain = \
+            Mock(return_value=0)
 
     def read_test_vectors(self, cloud_state, network_state=None):
         """Read test vectors for the various states."""

--- a/testdata/resources/config0.json
+++ b/testdata/resources/config0.json
@@ -6,7 +6,7 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
@@ -22,159 +22,214 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["forward-to-vip"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-cf.com",
-        "pool": "cf-cf.com",
+        "pool": "/cf/cf-cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10005",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-foo-e500900501f76ce8",
-        "pool": "cf-foo-e500900501f76ce8",
+        "pool": "/cf/cf-foo-e500900501f76ce8",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10000",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-bar-d21aa8a505891ac9",
-        "pool": "cf-bar-d21aa8a505891ac9",
+        "pool": "/cf/cf-bar-d21aa8a505891ac9",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10001",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-9a96ddcfe07bb46e",
-        "pool": "cf-baz-9a96ddcfe07bb46e",
+        "pool": "/cf/cf-baz-9a96ddcfe07bb46e",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10002",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-foo.cf.com",
-        "pool": "cf-foo.cf.com",
+        "pool": "/cf/cf-foo.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10006",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-ser_.cf.com",
-        "pool": "cf-ser_.cf.com",
+        "pool": "/cf/cf-ser_.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10007",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-ser_es.cf.com",
-        "pool": "cf-ser_es.cf.com",
+        "pool": "/cf/cf-ser_es.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10008",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-_vices.cf.com",
-        "pool": "cf-_vices.cf.com",
+        "pool": "/cf/cf-_vices.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10009",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-69cf12df3b85f455",
-        "pool": "cf-baz-69cf12df3b85f455",
+        "pool": "/cf/cf-baz-69cf12df3b85f455",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10003",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-beac6f8bec5a4446",
-        "pool": "cf-baz-beac6f8bec5a4446",
+        "pool": "/cf/cf-baz-beac6f8bec5a4446",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10004",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config1.json
+++ b/testdata/resources/config1.json
@@ -6,7 +6,7 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
@@ -22,84 +22,114 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["forward-to-vip"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-69cf12df3b85f455",
-        "pool": "cf-baz-69cf12df3b85f455",
+        "pool": "/cf/cf-baz-69cf12df3b85f455",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10003",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-beac6f8bec5a4446",
-        "pool": "cf-baz-beac6f8bec5a4446",
+        "pool": "/cf/cf-baz-beac6f8bec5a4446",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10004",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-cf.com",
-        "pool": "cf-cf.com",
+        "pool": "/cf/cf-cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10005",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-9a96ddcfe07bb46e",
-        "pool": "cf-baz-9a96ddcfe07bb46e",
+        "pool": "/cf/cf-baz-9a96ddcfe07bb46e",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10002",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-bar-d21aa8a505891ac9",
-        "pool": "cf-bar-d21aa8a505891ac9",
+        "pool": "/cf/cf-bar-d21aa8a505891ac9",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10001",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config2.json
+++ b/testdata/resources/config2.json
@@ -6,7 +6,7 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
@@ -22,99 +22,134 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["forward-to-vip"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-bar-d21aa8a505891ac9",
-        "pool": "cf-bar-d21aa8a505891ac9",
+        "pool": "/cf/cf-bar-d21aa8a505891ac9",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10001",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-69cf12df3b85f455",
-        "pool": "cf-baz-69cf12df3b85f455",
+        "pool": "/cf/cf-baz-69cf12df3b85f455",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10003",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-beac6f8bec5a4446",
-        "pool": "cf-baz-beac6f8bec5a4446",
+        "pool": "/cf/cf-baz-beac6f8bec5a4446",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10004",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-cf.com",
-        "pool": "cf-cf.com",
+        "pool": "/cf/cf-cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10005",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-9a96ddcfe07bb46e",
-        "pool": "cf-baz-9a96ddcfe07bb46e",
+        "pool": "/cf/cf-baz-9a96ddcfe07bb46e",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10002",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-qux-ac504dcd7f58634d",
-        "pool": "cf-qux-ac504dcd7f58634d",
+        "pool": "/cf/cf-qux-ac504dcd7f58634d",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10006",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config3.json
+++ b/testdata/resources/config3.json
@@ -6,7 +6,7 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
@@ -28,12 +28,18 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
+          "partition": "Common",
+          "context": "all"
         }, {
           "name": "fakeprofile",
-          "partition": "Common"
-        }],
-        "rules": ["forward-to-vip"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
@@ -54,118 +60,215 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
+          "partition": "Common",
+          "context": "all"
         }, {
           "name": "fakeprofile",
-          "partition": "Common"
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
         }, {
           "name": "clientssl",
-          "partition": "Common"
+          "partition": "Common",
+          "context": "clientside"
         }],
-        "rules": ["forward-to-vip"],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-baz-69cf12df3b85f455",
-        "pool": "cf-baz-69cf12df3b85f455",
+        "pool": "/cf/cf-baz-69cf12df3b85f455",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10003",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-baz-beac6f8bec5a4446",
-        "pool": "cf-baz-beac6f8bec5a4446",
+        "pool": "/cf/cf-baz-beac6f8bec5a4446",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10004",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-cf.com",
-        "pool": "cf-cf.com",
+        "pool": "/cf/cf-cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10005",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-foo.cf.com",
-        "pool": "cf-foo.cf.com",
+        "pool": "/cf/cf-foo.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10006",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-ser_.cf.com",
-        "pool": "cf-ser_.cf.com",
+        "pool": "/cf/cf-ser_.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10007",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-ser_es.cf.com",
-        "pool": "cf-ser_es.cf.com",
+        "pool": "/cf/cf-ser_es.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10008",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-baz-9a96ddcfe07bb46e",
-        "pool": "cf-baz-9a96ddcfe07bb46e",
+        "pool": "/cf/cf-baz-9a96ddcfe07bb46e",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10002",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-_vices.cf.com",
-        "pool": "cf-_vices.cf.com",
+        "pool": "/cf/cf-_vices.cf.com",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10009",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-bar-d21aa8a505891ac9",
-        "pool": "cf-bar-d21aa8a505891ac9",
+        "pool": "/cf/cf-bar-d21aa8a505891ac9",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10001",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }, {
         "name": "cf-foo-e500900501f76ce8",
-        "pool": "cf-foo-e500900501f76ce8",
+        "pool": "/cf/cf-foo-e500900501f76ce8",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:10000",
         "source": "10.0.0.1/32",
         "sourceAddressTranslation": {
           "type": "automap"
-        }
+        },
+        "profiles": [{
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }]
       }],
       "pools": [{
         "name": "cf-ser_.cf.com",

--- a/testdata/resources/config4.json
+++ b/testdata/resources/config4.json
@@ -6,53 +6,78 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
     "cf": {
       "virtualServers": [{
         "name": "cf-tcp-route-default-tcp-6010",
-        "pool": "cf-tcp-route-default-tcp-6010",
+        "pool": "/cf/cf-tcp-route-default-tcp-6010",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6010",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6020",
-        "pool": "cf-tcp-route-default-tcp-6020",
+        "pool": "/cf/cf-tcp-route-default-tcp-6020",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6020",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6030",
-        "pool": "cf-tcp-route-default-tcp-6030",
+        "pool": "/cf/cf-tcp-route-default-tcp-6030",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6030",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6040",
-        "pool": "cf-tcp-route-default-tcp-6040",
+        "pool": "/cf/cf-tcp-route-default-tcp-6040",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6040",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6050",
-        "pool": "cf-tcp-route-default-tcp-6050",
+        "pool": "/cf/cf-tcp-route-default-tcp-6050",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6050",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config5.json
+++ b/testdata/resources/config5.json
@@ -6,53 +6,78 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
     "cf": {
       "virtualServers": [{
         "name": "cf-tcp-route-default-tcp-6060",
-        "pool": "cf-tcp-route-default-tcp-6060",
+        "pool": "/cf/cf-tcp-route-default-tcp-6060",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6060",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6010",
-        "pool": "cf-tcp-route-default-tcp-6010",
+        "pool": "/cf/cf-tcp-route-default-tcp-6010",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6010",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6020",
-        "pool": "cf-tcp-route-default-tcp-6020",
+        "pool": "/cf/cf-tcp-route-default-tcp-6020",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6020",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6030",
-        "pool": "cf-tcp-route-default-tcp-6030",
+        "pool": "/cf/cf-tcp-route-default-tcp-6030",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6030",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }
       }, {
         "name": "cf-tcp-route-default-tcp-6040",
-        "pool": "cf-tcp-route-default-tcp-6040",
+        "pool": "/cf/cf-tcp-route-default-tcp-6040",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/127.0.0.1:6040",
+        "profiles": [{
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+        }],
         "sourceAddressTranslation": {
           "type": "automap"
         }

--- a/testdata/resources/config6.json
+++ b/testdata/resources/config6.json
@@ -6,23 +6,28 @@
     "partitions": ["cf"]
   },
   "global": {
-    "log-level": "debug",
+    "log-level": "info",
     "verify-interval": 30
   },
   "resources": {
     "cf": {
       "virtualServers": [{
         "name": "cf-foo-e500900501f76ce8",
-        "pool": "cf-foo-e500900501f76ce8",
+        "pool": "/cf/cf-foo-e500900501f76ce8",
         "ipProtocol": "tcp",
         "enabled": true,
         "destination": "/cf/10.0.0.1:65535",
         "source": "10.0.0.1/32",
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["jsessionid-persistence"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/jsessionid-persistence"],
         "sourceAddressTranslation": {
           "type": "automap"
         }
@@ -37,9 +42,14 @@
         }],
         "profiles": [{
           "name": "http",
-          "partition": "Common"
-        }],
-        "rules": ["forward-to-vip"],
+          "partition": "Common",
+          "context": "all"
+        }, {
+          "name": "tcp",
+          "partition": "Common",
+          "context": "all"
+          }],
+        "rules": ["/cf/forward-to-vip"],
         "sourceAddressTranslation": {
           "type": "automap"
         }


### PR DESCRIPTION
Problem:
The current config is missing properties that cccl is using as a
comparison which causes constant vs rewrites on the BIG-IP

Solution:
Add partition to object references
Add context to profiles
Add tcp profile to all vs
Update cccl pointer to pull in irule whitespace fix
Update test configs to verify output
Update default log level to "info" to match other controllers

Closes #72 