### PR TITLE
Per route config docs.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,26 @@ Release Notes for BIG-IP Controller for Cloud Foundry
 Added Functionality
 ```````````````````
 
+v1.1.0
+------
+
+Added Functionality
+```````````````````
+* Use the Controller as a Service Broker to apply per-route L7 (HTTP) configurations.
+
+  * Virtual Server for L7 (HTTP) route can have its own Policies, Profiles and SSL Profiles.
+  * Pool for L7 (HTTP) route can have its own load balancing mode and Health Monitors.
+
+* Adopts a new, two-tier architecture. See the BIG-IP Controller for Cloud Foundry documentation </containers/latest/cloudfoundry/#overview>_ for more information.
+* Support for JSESSIONID cookie session persistence.
+
+Limitations
+```````````
+* Architected only as a Static, Brokered Service.
+* Controller doesn't support Service bindings.
+* Controller cannot accept Arbitrary Parameters via `cf create-service|bind-service -c`.
+* Controller doesn't support the use of `cf update-service`.
+
 v1.0.0
 ------
 
@@ -36,4 +56,3 @@ Limitations
 * SSL profile(s) defined in the application manifest do not attach to the HTTP virtual server.
 * Modification of a Controller-owned policy resulting in a state change may cause traffic flow interruptions. If the modification changes the state to ‘published’, the Controller will delete the policy and recreate it with a ‘legacy’ status.
 * You cannot change the default route domain for a partition managed by an F5 controller after the controller has deployed. To specify a new default route domain, use a different partition.
-

--- a/docs/_static/config_examples/example-manifest.yml
+++ b/docs/_static/config_examples/example-manifest.yml
@@ -44,3 +44,31 @@ applications:
                         uri: http://api.system.pcf.local
                         port: 80
                         auth_disabled: false
+
+                      # Required to run as a Service Broker
+                      status:
+                        user: user
+                        pass: pass
+
+      # Only required if going to push controller as a Service Broker
+      SERVICE_BROKER_CONFIG: |
+                             plans:
+                              - description: plan for policy A,
+                                name: planA,
+                                virtualServer:
+                                  - policies:
+                                    - policyA
+                                  - profiles:
+                                    - profileA
+                                  - sslProfiles:
+                                    - sslProfileA
+                                pool:
+                                  balance: ratio-member
+                                  healthMonitors:
+                                    - name: /Common/http.get
+                                    - name: hm-test
+                                      type: http
+                                      interval: 12
+                                      timeout: 5
+                                      send: hello
+                                      recv: healthy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,7 @@ rst_epilog = '''
     <a href="http://clouddocs.f5.com/products/connectors/cf-bigip-ctlr/%(url_version)s/_static/ATTRIBUTIONS.html">Attributions</a>
 .. |cfctlr| replace:: :code:`cf-bigip-ctlr`
 .. |cfctlr-long| replace:: F5 BIG-IP Controller for Cloud Foundry
+.. _service broker: https://docs.cloudfoundry.org/services/managing-service-brokers.html
 ''' % {
     'url_version': version
 }


### PR DESCRIPTION
Problem:
  Current documentation does not cover per route configuration features.

Solution:
  Add documentation that covers this feature.