### PR TITLE
Release Notes for CCCL Virtual Server bug fix

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,10 @@ Release Notes for BIG-IP Controller for Cloud Foundry
 Added Functionality
 ```````````````````
 
+Bug Fixes
+`````````
+* Corrected a comparison problem in CCCL that caused unnecessary updates for BIG-IP Virtual Server resources.
+
 v1.0.0
 ------
 


### PR DESCRIPTION
Added a bug fix note for a comparison problem in CCCL that caused
unnecessary updates to occur for Virtual Servers on BIG-IP