### PR TITLE
Added variable CTLR_VERSION to travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
   - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
+  - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
   - make verify


### PR DESCRIPTION
Problem:
Travis script uses variable CTLR_VERSION to set version
string when deploying docs. This variable is not being set.

Solution:
Added variable CTLR_VERSION to travis.