### PR TITLE
Don't limit git clone depth in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 sudo: required
 services:
   - docker
+git:
+  # don't limit git clone depth
+  depth: false
 
 before_install:
   - docker pull golang:1.7.5


### PR DESCRIPTION
The default clone depth in Travis is 50. However, if there are
no git tags for the repo within the last 50 commits, the
'git describe' command will fail, so remove depth restriction.