### PR TITLE
Added startup retry callbacks.

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -461,9 +461,9 @@ class ConfigWatcher(pyinotify.ProcessEvent):
         self._config_stats = None
         if os.path.exists(self._config_file):
             try:
-                self._config_stats = self._md5()
+                self._config_stats = self._digest()
             except IOError as ioe:
-                log.warning('ioerror during md5 sum calculation: {}'.
+                log.warning('ioerror during sha sum calculation: {}'.
                             format(ioe))
 
         self._running = False
@@ -531,8 +531,8 @@ class ConfigWatcher(pyinotify.ProcessEvent):
         if self._user_abort:
             log.info('Received user kill signal, terminating.')
 
-    def _md5(self):
-        md5 = hashlib.md5()
+    def _digest(self):
+        sha = hashlib.sha256()
 
         with open(self._config_file, 'rb') as f:
             fcntl.lockf(f.fileno(), fcntl.LOCK_SH, 0, 0, 0)
@@ -540,9 +540,9 @@ class ConfigWatcher(pyinotify.ProcessEvent):
                 buf = f.read(4096)
                 if not buf:
                     break
-                md5.update(buf)
+                sha.update(buf)
             fcntl.lockf(f.fileno(), fcntl.LOCK_UN, 0, 0, 0)
-        return md5.digest()
+        return sha.digest()
 
     def _should_watch(self, pathname):
         if pathname == self._config_file:
@@ -559,13 +559,13 @@ class ConfigWatcher(pyinotify.ProcessEvent):
                 changed = False
         else:
             try:
-                cur_hash = self._md5()
+                cur_hash = self._digest()
                 if cur_hash != self._config_stats:
                     changed = True
                 else:
                     changed = False
             except IOError as ioe:
-                log.warning('ioerror during md5 sum calculation: {}'.
+                log.warning('ioerror during sha sum calculation: {}'.
                             format(ioe))
 
         return (changed, cur_hash)
@@ -585,26 +585,31 @@ class ConfigWatcher(pyinotify.ProcessEvent):
                 self._on_change()
 
         if self._should_watch(event.pathname):
-            (changed, md5) = self._is_changed()
+            (changed, sha) = self._is_changed()
 
             if changed:
                 log.debug('config file {0} changed - signalling bigip'.format(
-                    self._config_file, self._config_stats, md5))
-                self._config_stats = md5
+                    self._config_file, self._config_stats, sha))
+                self._config_stats = sha
                 self._on_change()
 
 
 def _parse_config(config_file):
-    if os.path.exists(config_file):
-        with open(config_file, 'r') as config:
-            fcntl.lockf(config.fileno(), fcntl.LOCK_SH, 0, 0, 0)
-            data = config.read()
-            fcntl.lockf(config.fileno(), fcntl.LOCK_UN, 0, 0, 0)
-            config_json = json.loads(data)
-            log.debug('loaded configuration file successfully')
-            return config_json
-    else:
-        return None
+    def _file_exist_cb():
+        if os.path.exists(config_file):
+            log.info('Config file: {} found'.format(config_file))
+            return (True, None)
+        else:
+            return (False, 'Waiting for config file {}'.format(config_file))
+    _retry_backoff(_file_exist_cb)
+
+    with open(config_file, 'r') as config:
+        fcntl.lockf(config.fileno(), fcntl.LOCK_SH, 0, 0, 0)
+        data = config.read()
+        fcntl.lockf(config.fileno(), fcntl.LOCK_UN, 0, 0, 0)
+        config_json = json.loads(data)
+        log.debug('loaded configuration file successfully')
+        return config_json
 
 
 def _handle_args():
@@ -726,6 +731,24 @@ def _set_user_agent():
     return user_agent
 
 
+def _retry_backoff(cb):
+    RETRY_INTERVAL = 1
+    log_interval = 0.5
+    elapsed = 0.5
+    while 1:
+        (success, val) = cb()
+        if success:
+            return val
+        if elapsed == log_interval:
+            elapsed = 0
+            log_interval *= 2
+            log.error("Encountered error: {}. Retrying for {} seconds.".format(
+                val, int(log_interval)
+            ))
+        time.sleep(RETRY_INTERVAL)
+        elapsed += RETRY_INTERVAL
+
+
 def main():
     try:
         args = _handle_args()
@@ -739,12 +762,19 @@ def main():
         #               may want to make the changes dynamic in the future.
 
         # BIG-IP to manage
-        bigip = mgmt_root(
-            host,
-            config['bigip']['username'],
-            config['bigip']['password'],
-            port,
-            "tmos")
+        def _bigip_connect_cb():
+            try:
+                bigip = mgmt_root(
+                    host,
+                    config['bigip']['username'],
+                    config['bigip']['password'],
+                    port,
+                    "tmos")
+                log.info('BIG-IP connection established.')
+                return (True, bigip)
+            except Exception, e:
+                return (False, 'BIG-IP connection error: {}'.format(e))
+        bigip = _retry_backoff(_bigip_connect_cb)
 
         # Read version and build info, set user-agent for ICR session
         user_agent = _set_user_agent()

--- a/python/tests/test_bigipconfigdriver.py
+++ b/python/tests/test_bigipconfigdriver.py
@@ -355,8 +355,9 @@ def test_configwatcher_init(request):
     assert watcher._running is False
 
     # Test with file on created
-    expected_digest = '\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04' + \
-        '\xe9\x80\t\x98\xec\xf8B~'
+    expected_digest = '\xe3\xb0\xc4\x42\x98\xfc\x1c\x14\x9a\xfb' + \
+        '\xf4\xc8\x99\x6f\xb9\x24\x27\xae\x41\xe4\x64\x9b\x93' + \
+        '\x4c\xa4\x95\x99\x1b\x78\x52\xb8\x55'
 
     os.mkdir(expected_dir)
     with open(expected_file, 'w+'):
@@ -397,10 +398,16 @@ def test_configwatcher_loop(request):
 
     expected_changes = [True, True, False, True, True, True]
     expected_digests = [
-        '\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04\xe9\x80\t\x98\xec\xf8B~',
-        '\xd7-\x16\xde\x92\xf2\xb6\xc1\x05\xce\xabj\x84\xcf\xcaz',
-        '\xd7-\x16\xde\x92\xf2\xb6\xc1\x05\xce\xabj\x84\xcf\xcaz', None,
-        '\xd7-\x16\xde\x92\xf2\xb6\xc1\x05\xce\xabj\x84\xcf\xcaz', None
+        '\xe3\xb0\xc4\x42\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99\x6f\xb9\x24' +
+        '\x27\xae\x41\xe4\x64\x9b\x93\x4c\xa4\x95\x99\x1b\x78\x52\xb8\x55',
+        '\x89\x49\x41\x1a\xf4\x39\x14\x13\x41\x0c\x77\x28\x5f\xe7\x90\x40' +
+        '\x1b\x35\x70\xae\xcc\x78\x93\xc2\xfe\x33\x1e\xe1\xe3\xd0\xf9\xfb',
+        '\x89\x49\x41\x1a\xf4\x39\x14\x13\x41\x0c\x77\x28\x5f\xe7\x90\x40' +
+        '\x1b\x35\x70\xae\xcc\x78\x93\xc2\xfe\x33\x1e\xe1\xe3\xd0\xf9\xfb',
+        None,
+        '\x89\x49\x41\x1a\xf4\x39\x14\x13\x41\x0c\x77\x28\x5f\xe7\x90\x40' +
+        '\x1b\x35\x70\xae\xcc\x78\x93\xc2\xfe\x33\x1e\xe1\xe3\xd0\xf9\xfb',
+        None
     ]
 
     watcher = bigipconfigdriver.ConfigWatcher(watch_file,
@@ -414,45 +421,45 @@ def test_configwatcher_loop(request):
     # IN_CREATE event
     os.mkdir(watch_dir)
     with open(watch_file, 'w+') as file_handle:
-        (changed, md5sum) = watcher._is_changed()
+        (changed, shasum) = watcher._is_changed()
         assert changed == expected_changes[0]
-        assert md5sum == expected_digests[0]
-        watcher._config_stats = md5sum
+        assert shasum == expected_digests[0]
+        watcher._config_stats = shasum
 
         file_handle.write('Senatus Populusque Romanus')
 
     # IN_CLOSE_WRITE event
-    (changed, md5sum) = watcher._is_changed()
+    (changed, shasum) = watcher._is_changed()
     assert changed == expected_changes[1]
-    assert md5sum == expected_digests[1]
-    watcher._config_stats = md5sum
+    assert shasum == expected_digests[1]
+    watcher._config_stats = shasum
 
     # IN_CLOSE_WRITE no change
     with open(watch_file, 'w') as file_handle:
         file_handle.write('Senatus Populusque Romanus')
-    (changed, md5sum) = watcher._is_changed()
+    (changed, shasum) = watcher._is_changed()
     assert changed == expected_changes[2]
-    assert md5sum == expected_digests[2]
+    assert shasum == expected_digests[2]
 
     # IN_MOVED_FROM event
     shutil.move(watch_file, watch_dir + '/file2')
-    (changed, md5sum) = watcher._is_changed()
+    (changed, shasum) = watcher._is_changed()
     assert changed == expected_changes[3]
-    assert md5sum == expected_digests[3]
-    watcher._config_stats = md5sum
+    assert shasum == expected_digests[3]
+    watcher._config_stats = shasum
 
     # IN_MOVED_TO event
     shutil.move(watch_dir + '/file2', watch_file)
-    (changed, md5sum) = watcher._is_changed()
+    (changed, shasum) = watcher._is_changed()
     assert changed == expected_changes[4]
-    assert md5sum == expected_digests[4]
-    watcher._config_stats = md5sum
+    assert shasum == expected_digests[4]
+    watcher._config_stats = shasum
 
     # IN_DELETE event
     os.unlink(watch_file)
-    (changed, md5sum) = watcher._is_changed()
+    (changed, shasum) = watcher._is_changed()
     assert changed == expected_changes[5]
-    assert md5sum == expected_digests[5]
+    assert shasum == expected_digests[5]
 
 
 def test_confighandler_lifecycle():
@@ -485,9 +492,6 @@ def test_parse_config(request):
         config_file = config_template.substitute(pid=os.getpid())
 
         handler = bigipconfigdriver.ConfigHandler(config_file, [mgr], 30)
-
-        r = bigipconfigdriver._parse_config(config_file)
-        assert r is None
 
         obj = {}
         obj['field1'] = 'one'


### PR DESCRIPTION
Problem
 -The bigipconfigdriver.py crashed during certain startup errors that
  are recoverable.
 -The bigipconfigdriver.py was once again out of sync with the k8s
  bigipconfigdriver.py.

Solution:
 -Add retry backoff callbacks for recoverable startup errors.
 - Bring bigipconfigdriver.py back into sync with k8s version.

Fixes: #113