### PR TITLE
Made tier2_ip_range optional.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,9 @@ type StatusConfig struct {
 	Pass string `yaml:"pass"`
 }
 
+// DefaultTier2IPRange is the default tier2 virtual server IP range
+var DefaultTier2IPRange = "172.0.0.0/24"
+
 // BigIPConfig configuration parameters for bigip integration
 type BigIPConfig struct {
 	URL               string   `yaml:"url" json:"url"`
@@ -102,13 +105,14 @@ var defaultBigIPConfig = BigIPConfig{
 	User:              "",
 	Pass:              "",
 	Partitions:        []string{},
-	LoadBalancingMode: "round-robin",
+	LoadBalancingMode: LoadBalancingStrategies[0],
 	VerifyInterval:    30,
 	ExternalAddr:      "",
 	SSLProfiles:       []string{},
 	Policies:          []string{},
 	Profiles:          []string{},
 	DriverCmd:         "",
+	Tier2IPRange:      DefaultTier2IPRange,
 }
 
 var defaultStatusConfig = StatusConfig{

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -118,7 +118,7 @@ Define the parameters in the ``env`` section of the `Controller application mani
    +----+-------------------------------------+---------+----------+----------------+---------------------------------------------------------------------------------+----------------------+
    |    | external_addr [#extaddr]_           | string  | Required | n/a            | Virtual address on the BIG-IP to use for cloud ingress.                         |                      |
    +----+-------------------------------------+---------+----------+----------------+---------------------------------------------------------------------------------+----------------------+
-   |    | tier2_ip_range                      | string  | Required | n/a            | IP range to assign to the tier2 vips (required in Service Broker mode only)     | Must use CIDR        |
+   |    | tier2_ip_range                      | string  | Optional | 172.0.0.0/24   | IP range to assign to the tier2 vips (required in Service Broker mode only)     | Must use CIDR        |
    |    |                                     |         |          |                |                                                                                 | notation             |
    +----+-------------------------------------+---------+----------+----------------+---------------------------------------------------------------------------------+----------------------+
    |    | ssl_profiles                        | array   | Optional | n/a            | List of BIG-IP SSL policies to attach to the HTTPS routing virtual server.      |                      |

--- a/f5router/f5router.go
+++ b/f5router/f5router.go
@@ -353,11 +353,10 @@ func (r *F5Router) validateConfig() error {
 		0 == len(r.c.BigIP.User) ||
 		0 == len(r.c.BigIP.Pass) ||
 		0 == len(r.c.BigIP.Partitions) ||
-		0 == len(r.c.BigIP.ExternalAddr) ||
-		0 == len(r.c.BigIP.Tier2IPRange) {
+		0 == len(r.c.BigIP.ExternalAddr) {
 		return fmt.Errorf(
 			"required parameter missing; URL, User, Pass, Partitions, ExternalAddr, "+
-				"Tier2IPRange must have value: %+v", r.c.BigIP)
+				"must have value: %+v", r.c.BigIP)
 	}
 
 	// Verify the ExternalAddr provided is a valid IP address
@@ -368,6 +367,12 @@ func (r *F5Router) validateConfig() error {
 	_, err := verifyDestAddress(va, r.c.BigIP.Partitions[0])
 	if nil != err {
 		return err
+	}
+
+	if len(r.c.BigIP.Tier2IPRange) == 0 {
+		r.c.BigIP.Tier2IPRange = config.DefaultTier2IPRange
+		r.logger.Info(
+			fmt.Sprintf("tier2_ip_range not set in config using default: %s", config.DefaultTier2IPRange))
 	}
 
 	ipAddr, ipNet, err := net.ParseCIDR(r.c.BigIP.Tier2IPRange)


### PR DESCRIPTION
Problem:
 The tier2_ip_range config param was a mandatory param which broker
 backwards compatibility.

Solution:
 Make tier2_ip_range optional with a sane default of 172.0.0.1/24 so it
 does not need to be required.

Fixes: #127