### PR TITLE
Metadata for BIG-IP LTM resources

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,10 @@ Release Notes for BIG-IP Controller for Cloud Foundry
 next-release
 ------------
 
+Added Functionality
+```````````````````
+Added controller name and version to the metadata of certain BIG-IP LTM resources managed by the controller.
+
 Bug Fixes
 `````````
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@295f017d8d3ddc8aa38c260309e28e337f12ef92#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@348a178b0e8ab364715c70ab374d6a3412257e0a#egg=f5-ctlr-agent


### PR DESCRIPTION
Added controller name and version to the metadata of certain
BIG-IP LTM resources managed by the controller.