### PR TITLE
tier2_ip_range needs more robust validation

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -11,6 +11,7 @@ Added controller name and version to the metadata of certain BIG-IP LTM resource
 Bug Fixes
 `````````
 * :issues:`150` - Fix go vet lock copy error
+* :issues:`134` - Add tier2_ip_range validation more robust to match BIG-IP input requirements.
 
 v1.1.1
 ------


### PR DESCRIPTION
Problem: The tier2_ip_range config parameter is only validated as being
a properly formatted CIDR block. However, it can be very easy as a user
to misconfigure this parameter causing errors on the BIG-IP creation of
tier2 VIPs. Prefixes should be evaluated to see if they fall on CIDR
block boundaries when users a trying to define networks with their
tier2_ip_range.

Solution: Added validation function and tests

Fixes #134