### PR TITLE
Fix govet errors in f5router.go

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added controller name and version to the metadata of certain BIG-IP LTM resource
 
 Bug Fixes
 `````````
+* :issues:`150` - Fix go vet lock copy error
 
 v1.1.1
 ------

--- a/f5router/f5router.go
+++ b/f5router/f5router.go
@@ -591,7 +591,7 @@ func initPartitionData(pm bigipResources.PartitionMap, partition string) {
 }
 
 // Populates a data group from the mutexBindIDRouteURIPlanNameMap
-func populateBrokerDataGroup(brokerData mutexBindIDRouteURIPlanNameMap) map[string]*bigipResources.InternalDataGroupRecord {
+func populateBrokerDataGroup(brokerData *mutexBindIDRouteURIPlanNameMap) map[string]*bigipResources.InternalDataGroupRecord {
 	dg := make(map[string]*bigipResources.InternalDataGroupRecord)
 
 	brokerData.lock.Lock()
@@ -634,7 +634,7 @@ func (r *F5Router) createResources() bigipResources.PartitionMap {
 
 	dataGroups := make(map[string]map[string]*bigipResources.InternalDataGroupRecord)
 	if r.c.BrokerMode {
-		brokerInternalDataGroup := populateBrokerDataGroup(r.bindIDRouteURIPlanNameMap)
+		brokerInternalDataGroup := populateBrokerDataGroup(&r.bindIDRouteURIPlanNameMap)
 		dataGroups[BrokerDataGroupName] = brokerInternalDataGroup
 	}
 	dataGroups[InternalDataGroupName] = r.internalDataGroup


### PR DESCRIPTION
Problem: Go vet reported a lock being passed by copy.

Solution: Remove copying of lock and pass by pointer.

Fixes #150