### PR TITLE
Update CCCL pointer for metadata bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@d6af54918f7523479f84f0fedee995452a7aed7e#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@435f049bf1a36c56293e57686d88a0bcd03e4cf6#egg=f5-ctlr-agent


### PR DESCRIPTION
CCCL incorrectly tried to get the length of a Nonetype. Metadata is a new addition to this version, so if upgrading controller versions, CCCL would hit this nonetype and throw an exception. CCCL now properly compares empty lists rather than Nonetypes.